### PR TITLE
Fixed Balance mode sensors. And add sensor.

### DIFF
--- a/packages/base.yml
+++ b/packages/base.yml
@@ -60,6 +60,9 @@ wifi:
 
 captive_portal:
 
+web_server:
+  port: 80
+
 # See docs: https://github.com/michaelarnauts/aiocomfoconnect/blob/master/docs/PROTOCOL-PDO.md
 zehnder_comfoair_q:
   id: comfoair

--- a/packages/button.yml
+++ b/packages/button.yml
@@ -64,4 +64,8 @@ button:
     icon: mdi:fan-chevron-down
     on_press:
       - lambda: id(comfoair)->set_bypass_mode(zehnder_comfoair_q::BYPASS_DEACTIVATE, 60 * 60);
+
+  - platform: restart  #Restart Button ESP
+    name: Restart
+    entity_category: diagnostic
       

--- a/packages/select.yml
+++ b/packages/select.yml
@@ -118,16 +118,16 @@ select:
     icon: mdi:arrow-split-vertical
     options:
      - "Balanced"
-     - "Supply only"
-     - "Exhaust only"
+     - "Supply Only"
+     - "Exhaust Only"
     optimistic: true
     restore_value: true
     set_action:
       - lambda: |
           if (x == "Balanced") {
             id(comfoair)->set_balance_mode(zehnder_comfoair_q::BALANCE_MODE_BALANCED);
-          } else if (x == "Supply only") {
+          } else if (x == "Supply Only") {
             id(comfoair)->set_balance_mode(zehnder_comfoair_q::BALANCE_MODE_SUPPLY_ONLY);
-          } else if (x == "Exhaust only") {
+          } else if (x == "Exhaust Only") {
             id(comfoair)->set_balance_mode(zehnder_comfoair_q::BALANCE_MODE_EXHAUST_ONLY);
           }

--- a/packages/sensors.yml
+++ b/packages/sensors.yml
@@ -346,3 +346,30 @@ sensor:
     unit_of_measurement: '%'
     device_class: humidity
     state_class: measurement
+
+ - platform: wifi_signal # Reports the WiFi signal strength/RSSI in dB
+    name: "Signaal dB"
+    id: wifi_signal_db
+    update_interval: 60s
+    entity_category: "diagnostic"
+    
+  - platform: copy # Reports the WiFi signal strength in %
+    source_id: wifi_signal_db
+    name: "Signaal &"
+    filters:
+      - lambda: return min(max(2 * (x + 100.0), 0.0), 100.0);
+    unit_of_measurement: " %"
+    entity_category: "diagnostic"
+    device_class: ""
+    
+  - platform: uptime # Reports Uptime of ESP
+    name: Uptime
+    disabled_by_default: false
+    force_update: false
+    unit_of_measurement: s
+    icon: mdi:timer-outline
+    accuracy_decimals: 0
+    device_class: duration
+    state_class: total_increasing
+    entity_category: diagnostic
+    update_interval: 60s    

--- a/packages/text_sensors.yml
+++ b/packages/text_sensors.yml
@@ -93,9 +93,8 @@ text_sensor:
     icon: mdi:arrow-split-vertical
     on_value:
       then:
-        - select.set:
-            id: balance_mode_select
-            option: x
+        - lambda: id(balance_mode_select).publish_state(x);
+
 
 
   - platform: template

--- a/packages/text_sensors.yml
+++ b/packages/text_sensors.yml
@@ -134,3 +134,16 @@ text_sensor:
         - 0 -> Disabled
         - 1 -> Active
         - 2 -> Overruling
+
+  - platform: wifi_info  #Reports Wifi info
+    ip_address:
+      name: IP
+    ssid:
+      name: SSID
+      
+  - platform: version # Reports ESP Version
+    name: Version
+    hide_timestamp: true
+    disabled_by_default: false
+    icon: mdi:new-box
+    entity_category: diagnostic


### PR DESCRIPTION
Thanks for the work. There's an error in the text sensor causing you to get an error that X doesn't exist. This fixes it:
text_sensors.yml
```
  - platform: template
    id: balance_mode # PDO 55
    name: 'Balance Mode'
    icon: mdi:arrow-split-vertical
    on_value:
      then:
        - lambda: id(balance_mode_select).publish_state(x);
```
Okay, there's a name difference in the options of the text sensor and select. The 'o' in 'only' is not capitalized. Here's the solution.
Select.yml
```
  - platform: template
    name: 'Balance mode'
    id: balance_mode_select
    icon: mdi:arrow-split-vertical
    options:
     - "Balanced"
     - "Supply Only"
     - "Exhaust Only"
    optimistic: true
    restore_value: true
    set_action:
      - lambda: |
          if (x == "Balanced") {
            id(comfoair)->set_balance_mode(zehnder_comfoair_q::BALANCE_MODE_BALANCED);
          } else if (x == "Supply Only") {
            id(comfoair)->set_balance_mode(zehnder_comfoair_q::BALANCE_MODE_SUPPLY_ONLY);
          } else if (x == "Exhaust Only") {
            id(comfoair)->set_balance_mode(zehnder_comfoair_q::BALANCE_MODE_EXHAUST_ONLY);
          }
```

Also add some sensors:
- IP Adress
- SSID
- ESP Version
- Restart Button
- Wifi Signal
- UPtime