### PR TITLE
Set flash size correctly for Atom lite

### DIFF
--- a/boards/m5stack-atom.yml
+++ b/boards/m5stack-atom.yml
@@ -4,4 +4,4 @@ substitutions:
   can_rx_pin: GPIO32
   board: m5stack-atom
   variant: esp32
-  flash_size: 8MB
+  flash_size: 4MB


### PR DESCRIPTION
Upon running `make upload BOARD=m5stack-atom` it ended up in a fail loop throwing:

```
[15:59:22]E (628) spi_flash: Detected size(4096k) smaller than the size in the binary image header(8192k). Probe failed.
```

Changed the flash size to 4MB and it worked.