### PR TITLE
Update Wiring diagram with correct color code

### DIFF
--- a/docs/m5stack-atoms3.md
+++ b/docs/m5stack-atoms3.md
@@ -32,8 +32,8 @@ Here is a picture of the finished setup:
 |                 |     |     [TJA1051T/3]     | Grove |             |
 | (red)       12V o-----o HV               RXD o=======o GPIO1       |
 | (black)     GND o-----o GND              TXD o=======o GPIO2       |
-| (yellow)  CAN_L o-----o CAN_L             5V o=======o 5V          |
-| (white)   CAN_H o-----o CAN_H            GND o=======o GND         |
+| (white)   CAN_L o-----o CAN_L             5V o=======o 5V          |
+| (yellow)  CAN_H o-----o CAN_H            GND o=======o GND         |
 |                 |     |                      |       |             |
 |-----------------+     +----------------------+       +-------------+
 ```


### PR DESCRIPTION
Based on the datasheet of the confoairQ, the CAN High is the yellow wire: https://www.zehnderamerica.com/wp-content/uploads/2019/04/ComfoAir-Q-Service-Manual.pdf

While the picture are correct, the markdown is wrong