### PR TITLE
Add support for Waveshare ESP32-S3-RS485-CAN

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,21 @@
+FROM mcr.microsoft.com/devcontainers/python:1-3.12-bookworm
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1
+
+RUN rm -f /etc/apt/sources.list.d/yarn.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        avahi-utils \
+        build-essential \
+        ca-certificates \
+        curl \
+        dnsutils \
+        git \
+        iproute2 \
+        iputils-ping \
+        make \
+        usbutils \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install uv==0.11.25

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,35 @@
+{
+  "name": "ESPHome Zehnder ComfoAir",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "workspaceFolder": "/workspaces/esphome-zehnder-comfoair",
+  "postCreateCommand": "cp -n secrets.yaml.example secrets.yaml && make help",
+  "remoteUser": "vscode",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "esphome.esphome-vscode",
+        "redhat.vscode-yaml",
+        "ms-vscode.cpptools",
+        "ms-python.python",
+        "ms-vscode.makefile-tools",
+        "ms-azuretools.vscode-docker",
+        "editorconfig.editorconfig",
+        "streetsidesoftware.code-spell-checker",
+        "timonwong.shellcheck"
+      ],
+      "settings": {
+        "yaml.customTags": [
+          "!include scalar",
+          "!secret scalar"
+        ],
+        "files.associations": {
+          "*.yml": "yaml",
+          "*.yaml": "yaml"
+        }
+      }
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,6 +5,10 @@
     "context": ".."
   },
   "workspaceFolder": "/workspaces/esphome-zehnder-comfoair",
+  "runArgs": [
+    "--privileged",
+    "--group-add=dialout"
+  ],
   "postCreateCommand": "cp -n secrets.yaml.example secrets.yaml && make help",
   "remoteUser": "vscode",
   "customizations": {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,89 @@
+# AGENTS.md
+
+This repository contains ESPHome configuration, packages, board definitions, and
+custom components for Zehnder ComfoAir Q devices.
+
+## Operating Principles
+
+- Keep the repository usable as a normal ESPHome project and as a reusable
+  package source.
+- Prefer small, reviewable changes that preserve existing board variants.
+- Do not commit Wi-Fi credentials, API keys, OTA passwords, device-specific
+  secrets, generated firmware, or local build caches.
+- Treat hardware-facing behavior carefully. Changes to CAN bus handling,
+  ventilation commands, sensors, or protocol parsing should be validated with
+  config/build checks before being tested on real equipment.
+- Keep project automation reproducible through the Makefile and devcontainer
+  rather than relying on manually installed global tools.
+
+## Common Commands
+
+Use the Makefile as the main entrypoint:
+
+```bash
+make help
+make validate-config
+make compile
+make compile BOARD=m5stack-atoms3
+make compile BOARD=esp32-evb
+```
+
+The Makefile reads the ESPHome version from `requirements.txt` and runs ESPHome
+through `uvx`. If `uv` is missing, install it in the devcontainer or VM package
+setup instead of changing the project commands.
+
+## Devcontainer
+
+- Keep devcontainer files under `.devcontainer/`.
+- The container should include Python, `uv`, `make`, build tools, and basic
+  network troubleshooting tools.
+- VS Code extensions should be declared in `devcontainer.json`, especially YAML
+  and C++ support.
+- Validate the container with `make help`, then `make validate-config`, then a
+  board-specific `make compile`.
+
+## Secrets And Local State
+
+- `secrets.yaml` is local-only and must not be committed.
+- Start from `secrets.yaml.example` when a local secrets file is needed.
+- `.esphome/`, PlatformIO build output, generated firmware, and temporary logs
+  are local artifacts.
+- If shared secrets are mounted from a host or VM path, use a symlink or mount
+  that stays outside Git.
+
+## ESPHome And YAML
+
+- Preserve existing package and substitution structure unless a refactor is
+  needed for the requested change.
+- Keep board-specific settings in `boards/` or the existing board YAML files.
+- Keep reusable configuration in `packages/`.
+- When adding YAML tags or patterns that editors may not understand, update the
+  devcontainer or workspace YAML settings rather than weakening validation.
+
+## Custom Components
+
+- Keep C++ component changes focused and compatible with the ESPHome version in
+  `requirements.txt`.
+- Avoid broad protocol rewrites without adding a clear validation path.
+- Prefer explicit names and comments for protocol constants, frame layouts, and
+  unit conversions.
+- After changing component code, run at least `make validate-config` and one
+  relevant `make compile`.
+
+## Flashing And Logs
+
+- Prefer compile-only verification in automated or remote agent work.
+- Do not flash devices or start long-running logs unless the user explicitly
+  asks for it and confirms the target device.
+- For OTA usage, confirm the board and target host suffix before running
+  `make upload` or `make logs`.
+- For USB flashing, confirm where the USB device is attached and whether the
+  container has access to the serial device.
+
+## Style
+
+- Use ASCII unless an existing file clearly uses another character set.
+- Keep documentation concise and operational.
+- Match the existing Makefile, YAML, Python, and C++ style.
+- Do not reformat unrelated files.
+- Update README or board/package docs when user-facing behavior changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,18 @@ setup instead of changing the project commands.
   network troubleshooting tools.
 - VS Code extensions should be declared in `devcontainer.json`, especially YAML
   and C++ support.
+- Build and validate board-specific changes inside the devcontainer. If the
+  `devcontainer` CLI is unavailable, build the image from `.devcontainer` and
+  run the Makefile inside it:
+
+```bash
+docker build -f .devcontainer/Dockerfile -t esphome-zehnder-comfoair-devcontainer .
+docker run --rm -v "$PWD":/workspaces/esphome-zehnder-comfoair \
+  -w /workspaces/esphome-zehnder-comfoair \
+  esphome-zehnder-comfoair-devcontainer \
+  bash -lc 'make validate-config BOARD=waveshare-esp32-s3-rs485-can && make compile BOARD=waveshare-esp32-s3-rs485-can'
+```
+
 - Validate the container with `make help`, then `make validate-config`, then a
   board-specific `make compile`.
 

--- a/boards/waveshare-esp32-s3-rs485-can.yml
+++ b/boards/waveshare-esp32-s3-rs485-can.yml
@@ -1,0 +1,34 @@
+# Waveshare ESP32-S3-RS485-CAN
+substitutions:
+  can_tx_pin: GPIO15
+  can_rx_pin: GPIO16
+  rs485_tx_pin: GPIO17
+  rs485_rx_pin: GPIO18
+  rs485_flow_control_pin: GPIO21
+  rs485_baud_rate: "9600"
+  i2c_sda_pin: GPIO39
+  i2c_scl_pin: GPIO38
+  header_gpio1_pin: GPIO1
+  header_gpio2_pin: GPIO2
+  board: esp32-s3-devkitc-1
+  variant: esp32s3
+  flash_size: 16MB
+
+uart:
+  - id: waveshare_rs485
+    tx_pin: ${rs485_tx_pin}
+    rx_pin: ${rs485_rx_pin}
+    flow_control_pin: ${rs485_flow_control_pin}
+    baud_rate: ${rs485_baud_rate}
+
+i2c:
+  - id: waveshare_i2c
+    sda: ${i2c_sda_pin}
+    scl: ${i2c_scl_pin}
+    scan: true
+
+time:
+  - platform: pcf85063
+    id: waveshare_rtc
+    i2c_id: waveshare_i2c
+    address: 0x51

--- a/docs/waveshare-esp32-s3-rs485-can.md
+++ b/docs/waveshare-esp32-s3-rs485-can.md
@@ -1,0 +1,190 @@
+# Connecting Zehnder ComfoAir Q with Waveshare ESP32-S3-RS485-CAN
+
+This board is a validated DIN-rail option for this project. It has been tested
+successfully with the Zehnder ComfoAir Q configuration in this repository using
+the unit's ComfoNet screw terminals for CAN and 12 V power.
+
+## Why this board is relevant
+
+- DIN-rail ABS enclosure, suitable for a short wall-mounted rail near the unit
+- Built-in isolated CAN interface on screw terminals
+- Built-in isolated RS485 interface on screw terminals
+- 7-36 V DC power input on screw terminals
+
+The RS485 interface is not used by the current Zehnder ComfoAir Q ESPHome
+configuration, but it may be useful for additional equipment in the same
+cabinet.
+
+## ESPHome pin mapping
+
+| Function | Pin |
+| --- | --- |
+| CAN TX | `GPIO15` |
+| CAN RX | `GPIO16` |
+| RS485 TX | `GPIO17` |
+| RS485 RX | `GPIO18` |
+| RS485 TX enable / DE | `GPIO21` |
+| I2C SCL | `GPIO38` |
+| I2C SDA | `GPIO39` |
+| Header GPIO1 | `GPIO1` |
+| Header GPIO2 | `GPIO2` |
+
+Expected board substitutions:
+
+```yaml
+substitutions:
+  can_tx_pin: GPIO15
+  can_rx_pin: GPIO16
+  rs485_tx_pin: GPIO17
+  rs485_rx_pin: GPIO18
+  rs485_flow_control_pin: GPIO21
+  rs485_baud_rate: "9600"
+  i2c_sda_pin: GPIO39
+  i2c_scl_pin: GPIO38
+  header_gpio1_pin: GPIO1
+  header_gpio2_pin: GPIO2
+  board: esp32-s3-devkitc-1
+  variant: esp32s3
+  flash_size: 16MB
+```
+
+Board-specific component IDs exposed by this variant:
+
+| Feature | ESPHome ID |
+| --- | --- |
+| RS485 UART | `waveshare_rs485` |
+| I2C bus | `waveshare_i2c` |
+| PCF85063 RTC | `waveshare_rtc` |
+
+Build this variant with:
+
+```sh
+make validate-config BOARD=waveshare-esp32-s3-rs485-can
+make compile BOARD=waveshare-esp32-s3-rs485-can
+```
+
+## Zehnder CAN wiring
+
+If a verified 12 V supply from the ventilation unit is available, it can power
+the Waveshare board directly through the `DC+` / `DC-` power terminal.
+
+```
+
+|----------------+                                +------------------------------+
+|                |                                |                              |
+|   [ComfoAir]   |                                | [Waveshare ESP32-S3-RS485-CAN]
+|                |                                |                              |
+|             12V o-------------------------------o DC+                          |
+|             GND o-------------------------------o DC-                          |
+|           CAN_H o-------------------------------o CAN H                        |
+|           CAN_L o-------------------------------o CAN L                        |
+|----------------+                                +------------------------------+
+```
+
+The tested setup uses the ComfoNet screw terminals:
+
+| ComfoNet terminal | Signal | Waveshare terminal |
+| --- | --- | --- |
+| red / 12V | +12 V | `DC+` |
+| black / GND | 0 V / GND | `DC-` |
+| yellow / CAN_H | CAN-H | `H` |
+| white / CAN_L | CAN-L | `L` |
+
+This terminal wiring has been validated with the Waveshare board and the normal
+ESPHome project.
+
+## RJ45 ComfoNet wiring
+
+Zehnder documents ComfoNet as a combined CAN bus and 12 V supply. The official
+ComfoConnect documentation gives this signal set and color code for the
+4-core ComfoNet cable:
+
+| Signal | Official ComfoNet color |
+| --- | --- |
+| CAN_L | white |
+| CAN_H | yellow |
+| GND | black |
+| 12V | red |
+
+For the ComfoAir Q RJ45 socket, existing community projects document the
+following RJ45 pin mapping. The signal pins stay the same, but wire colors
+depend on whether the cable is wired as T568A or T568B.
+
+T568B cable colors:
+
+| T568B RJ45 pin | RJ45 wire | Signal | Waveshare terminal |
+| --- | --- | --- | --- |
+| 1 | white-orange | CAN-L | `L` |
+| 2 | orange | CAN-H | `H` |
+| 3 | white-green | GND | `DC-` |
+| 4 | blue | +12 V | `DC+` |
+
+T568A cable colors:
+
+| T568A RJ45 pin | RJ45 wire | Signal | Waveshare terminal |
+| --- | --- | --- | --- |
+| 1 | white-green | CAN-L | `L` |
+| 2 | green | CAN-H | `H` |
+| 3 | white-orange | GND | `DC-` |
+| 4 | blue | +12 V | `DC+` |
+
+Only use the RJ45 12 V line after verifying the actual cable and socket with a
+multimeter. Do not connect unused RJ45 conductors. For stripped patch cables,
+identify the RJ45 pins with a continuity tester instead of relying on wire color
+alone; crossover, mixed-standard, or non-network cables may not follow the color
+tables above.
+
+## Powering from the unit's 12 V supply
+
+Direct 12 V power is suitable because Waveshare specifies the power screw
+terminal for 7-36 V DC input. Use this wiring only after checking the real
+connector:
+
+- `+12 V` to `DC+`
+- `0 V` / `GND` to `DC-`
+- CAN-H to `H`
+- CAN-L to `L`
+
+Before permanent operation:
+
+- Verify the 12 V polarity with a multimeter.
+- Verify that the 12 V output has enough spare current for the board.
+- Add a small inline fuse if the source is not already suitably protected.
+
+## Mounting notes
+
+The DIN-rail enclosure is still useful without a full cabinet. Practical options
+for this project are:
+
+- on a short wall-mounted DIN rail near the Zehnder unit
+- on a small DIN-rail plate fixed next to the service opening
+- lying inside the Zehnder unit only if it is mechanically secured, kept away
+  from moving parts, airflow paths, condensate, and serviceable high-voltage
+  areas
+
+For Wi-Fi reliability, avoid mounting the board behind large metal covers. If
+the signal is weak, test the location with the enclosure closed before final
+mounting.
+
+## CAN notes
+
+- Waveshare's demo default CAN bitrate is 250 kbit/s.
+- This repository uses 50 kbit/s for Zehnder ComfoAir Q in `packages/canbus.yml`.
+- Use the project bitrate, not the Waveshare demo default.
+- The board has a reserved 120 ohm CAN termination option, but Waveshare
+  documents it as not connected by default.
+- The CAN bus must be correctly terminated for reliable operation.
+- CAN tests without another device at the same bitrate commonly produce ACK or
+  bus errors.
+
+## Sources
+
+- Waveshare Wiki: https://www.waveshare.com/wiki/ESP32-S3-RS485-CAN
+- Product page: https://www.waveshare.com/esp32-s3-rs485-can.htm
+- Demo ZIP: https://files.waveshare.com/wiki/ESP32-S3-RS485-CAN/ESP32-S3-RS485-CAN-Demo.zip
+- Schematic: https://files.waveshare.com/wiki/ESP32-S3-RS485-CAN/ESP32-S3-RS485-CAN-Schematic.pdf
+- Zehnder ComfoAir Q service manual: https://zehnderamerica.com/wp-content/uploads/2024/08/ComfoAir_Q_Service_Zehnder-America_EN_2022.05.18.pdf
+- Zehnder ComfoConnect LAN C manual: https://www.thebuiltenvironment.co.uk/wp-content/uploads/2023/07/A.-Zehnder-LAN-C-User-and-Installation-Manual.pdf
+- Zehnder ComfoConnect PRO technical sheet: https://dokumenty.maro.cz/prilohy/Zehnder_ComfoConnect_PRO_471429300_technicky_list.pdf
+- dan-s-github Zehnder ComfoAir CAN RJ45 wiring: https://github.com/dan-s-github/zehnder-comfoair-can/blob/main/M5STACK_CAN_BUS_KIT.md
+- dan-s-github custom PCB RJ45 and terminal wiring: https://github.com/dan-s-github/zehnder-comfoair-can/blob/main/CUSTOM_PCB.md

--- a/zehnder-comfoair-q-waveshare-esp32-s3-rs485-can.dashboard.yml
+++ b/zehnder-comfoair-q-waveshare-esp32-s3-rs485-can.dashboard.yml
@@ -1,0 +1,4 @@
+<<: !include zehnder-comfoair-q-waveshare-esp32-s3-rs485-can.yml
+
+# override external_components to use the dashboard version
+external_components: !include packages/external_components.dashboard.yml

--- a/zehnder-comfoair-q-waveshare-esp32-s3-rs485-can.yml
+++ b/zehnder-comfoair-q-waveshare-esp32-s3-rs485-can.yml
@@ -1,0 +1,8 @@
+external_components: !include packages/external_components.yml
+
+packages:
+  base: !include packages/base.yml
+  device_base: !include boards/waveshare-esp32-s3-rs485-can.yml
+
+dashboard_import:
+  package_import_url: github://yoziru/esphome-zehnder-comfoair/zehnder-comfoair-q-waveshare-esp32-s3-rs485-can.dashboard.yml


### PR DESCRIPTION
The [Waveshare ESP32-S3-RS485-CAN](https://www.waveshare.com/wiki/ESP32-S3-RS485-CAN) module is a perfect fit for this project, as it comes with everything needed to work out of the box. 
I've just successfully tested it with my Q350 TR.

My PR also includes minor additions for easy project setup with a devcontainer and an `AGENTS.md` for working with LLM support. Please tell me, if I should remove that changes.