### PR TITLE
Replace secret keys with environment variable syntax

### DIFF
--- a/packages/base.yml
+++ b/packages/base.yml
@@ -35,20 +35,20 @@ logger:
 
 api:
   encryption:
-    key: !secret api_encryption_key
+    key: ${api_encryption_key}
 
 ota:
   platform: esphome
-  password: !secret ota_password
+  password: ${ota_password}
 
 wifi:
-  ssid: !secret wifi_ssid
-  password: !secret wifi_password
+  ssid: ${wifi_ssid}
+  password: ${wifi_password}
   enable_rrm: true
   enable_btm: true
   # Enable fallback hotspot (captive portal) in case wifi connection fails
   ap:
-    password: !secret wifi_hotspot_password
+    password: ${wifi_hotspot_password}
 
 captive_portal:
 improv_serial:


### PR DESCRIPTION
The documentation mentions using substitutions for injecting user-defined secrets.

However, these are currently listed directly as secrets, and therefore fail validation even when overridden. 

Since I use differently named secrets i would like to suggest using the documented substitutions