### PR TITLE
fix: Web Installer 404

### DIFF
--- a/.github/workflows/publish-common.yml
+++ b/.github/workflows/publish-common.yml
@@ -63,6 +63,7 @@ jobs:
         run: |
           mkdir output
           mv "${{ steps.esphome-build.outputs.name }}" output/
+          mv manifest.json output/
           echo ${{ steps.esphome-build.outputs.version }} > output/version
           echo ${{ steps.esphome-build.outputs.project-version }} > output/project_version
       - uses: actions/upload-artifact@v4.6.2


### PR DESCRIPTION
Closes #61

Patch generated by `qwen3.6-35b-a3b via local API`.